### PR TITLE
fix #36: rpm dependencies

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,3 +77,9 @@ nfpms:
     scripts:
         postinstall: "resources/scripts/postinst"
         postremove:  "resources/scripts/postrm"
+
+    overrides:
+      rpm:
+        dependencies:
+          - glibc
+          - gtk3


### PR DESCRIPTION
Fixes #36 
Overrides goreleaser rpm dependencies and sets them as glibc and gtk3