### PR TITLE
Improvements on Album Art display

### DIFF
--- a/internal/player/main-window.go
+++ b/internal/player/main-window.go
@@ -179,7 +179,8 @@ const (
 	queueSaveNewPlaylistID = "\u0001new"
 	librarySearchAllAttrID = "\u0001any"
 
-	playerArtworkSize = 80 // Album artwork size in pixels
+	artMinHeight = 80 // Album artwork size in pixels
+	artMaxHeight = 160
 )
 
 type triBool int
@@ -2272,9 +2273,13 @@ func (w *MainWindow) updatePlayerAlbumArt(uri string) {
 				// Make a pixbuf from the data bytes
 				px, err := gdk.PixbufNewFromBytesOnly(albumArt)
 				if !errCheck(err, "PixbufNewFromBytesOnly() failed") {
-					// Downscale the image if needed
-					destWidth := playerArtworkSize * px.GetWidth() / px.GetHeight()
-					px, err := px.ScaleSimple(destWidth, playerArtworkSize, gdk.INTERP_BILINEAR)
+					// Down/up-scale the image as needed
+					_, windowHeight := w.AppWindow.GetSize()
+					destHeight := util.Remap(windowHeight, 460, 660, artMinHeight, artMaxHeight)
+					destHeight = util.Clamp(destHeight, artMinHeight, artMaxHeight)
+					destWidth := destHeight * px.GetWidth() / px.GetHeight()
+
+					px, err := px.ScaleSimple(destWidth, destHeight, gdk.INTERP_BILINEAR)
 					if !errCheck(err, "ScaleSimple() failed") {
 						w.AlbumArtworkImage.SetFromPixbuf(px)
 						show = true

--- a/internal/player/main-window.go
+++ b/internal/player/main-window.go
@@ -2273,7 +2273,8 @@ func (w *MainWindow) updatePlayerAlbumArt(uri string) {
 				px, err := gdk.PixbufNewFromBytesOnly(albumArt)
 				if !errCheck(err, "PixbufNewFromBytesOnly() failed") {
 					// Downscale the image if needed
-					px, err := px.ScaleSimple(playerArtworkSize, playerArtworkSize, gdk.INTERP_BILINEAR)
+					destWidth := playerArtworkSize * px.GetWidth() / px.GetHeight()
+					px, err := px.ScaleSimple(destWidth, playerArtworkSize, gdk.INTERP_BILINEAR)
 					if !errCheck(err, "ScaleSimple() failed") {
 						w.AlbumArtworkImage.SetFromPixbuf(px)
 						show = true

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -121,3 +121,18 @@ func ReadPicture(c *mpd.Client, uri string) ([]byte, error) {
 	}
 	return data, nil
 }
+
+// The given value will be truncated to stay inside a given range
+func Clamp(value, min, max int) int {
+	if value < min {
+		return min
+	} else if value > max {
+		return max
+	}
+	return value
+}
+
+// Uses linear interpolation to remap a value from range A to value in range B
+func Remap(ax, a1, a2, b1, b2 int) int {
+	return b1 + (b2-b1)*(ax-a1)/(a2-a1)
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -99,3 +99,25 @@ func MapAttrsToSlice(attrs []mpd.Attrs, attr string) []string {
 	}
 	return r
 }
+
+// ReadPicture retrieves the embedded album artwork image for a song with the given URI using MPD's readpicture command.
+// Must be removed and replaced by c.ReadPicture() when the feature is released on gompd
+func ReadPicture(c *mpd.Client, uri string) ([]byte, error) {
+	offset := 0
+	var data []byte
+	for {
+		// Read the data in chunks
+		chunk, size, err := c.Command("readpicture %s %d", uri, offset).Binary()
+		if err != nil {
+			return nil, err
+		}
+
+		// Accumulate the data
+		data = append(data, chunk...)
+		offset = len(data)
+		if offset >= size {
+			break
+		}
+	}
+	return data, nil
+}


### PR DESCRIPTION
I couldn't live without this anymore, every album art I have is embedded, not a single `cover.jpg` anywhere. I learned some GO now!

* Implements #52. I added the **ReadPicture** method that wasn't released yet in `gompd`. After their update, it can be replaced seamlessly.
* Put **ReadPicture** preferred over **AlbumArt** since it's more specific.
* Fixed image aspect ratio when scaling.
* Set up dynamic image size, based on window height. It doesn't change in real time while resizing the window though: it seems like this is very cumbersome thing to do in GTK.

Thank you, i hope you like it!