### PR TITLE
Use settings portal to switch to light/dark variants of theme

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,8 @@ require (
 	github.com/gotk3/gotk3 v0.6.5-0.20240618185848-ff349ae13f56
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 )
+
+require (
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
+	golang.org/x/sys v0.27.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
 github.com/fhs/gompd/v2 v2.3.0 h1:wuruUjmOODRlJhrYx73rJnzS7vTSXSU7pWmZtM3VPE0=
 github.com/fhs/gompd/v2 v2.3.0/go.mod h1:nNdZtcpD5VpmzZbRl5rV6RhxeMmAWTxEsSIMBkmMIy4=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/gotk3/gotk3 v0.6.5-0.20240618185848-ff349ae13f56 h1:eR+xxC8qqKuPMTucZqaklBxLIT7/4L7dzhlwKMrDbj8=
 github.com/gotk3/gotk3 v0.6.5-0.20240618185848-ff349ae13f56/go.mod h1:/hqFpkNa9T3JgNAE2fLvCdov7c5bw//FHNZrZ3Uv9/Q=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/internal/player/main-window.go
+++ b/internal/player/main-window.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gotk3/gotk3/gtk"
 	"github.com/yktoo/ymuse/internal/config"
 	"github.com/yktoo/ymuse/internal/util"
+	"github.com/godbus/dbus/v5"
 )
 
 // MainWindow represents the main application window
@@ -257,6 +258,11 @@ func NewMainWindow(application *gtk.Application) (*MainWindow, error) {
 		"on_StreamsDeleteMenuItem_activate":            w.onStreamDelete,
 	})
 
+	glib.IdleAdd(func() {
+		w.syncWithPortal()
+	})
+	w.watchThemeChanges()
+	
 	// Register the main window with the app
 	application.AddWindow(w.AppWindow)
 
@@ -2826,4 +2832,65 @@ func (w *MainWindow) updateVolume() {
 		w.VolumeAdjustment.SetValue(float64(vol))
 		w.volumeUpdating = false
 	}
+}
+
+// IsSystemDarkMode tell if the system set to dark mode using the xdg portal
+func IsSystemDarkMode() bool {
+	
+	// https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Settings.html
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return false
+	}
+
+	obj := conn.Object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
+	
+	var variant dbus.Variant
+	err = obj.Call("org.freedesktop.portal.Settings.Read", 0, "org.freedesktop.appearance", "color-scheme").Store(&variant)
+	if err != nil {
+		return false
+	}
+
+	var scheme uint32
+	if err := variant.Value().(dbus.Variant).Store(&scheme); err != nil {
+		return false
+	}
+
+	return scheme == 1
+}
+
+// syncWithPortal update the gtk properties to use the system prefered light/dark theme
+func (w *MainWindow) syncWithPortal() {
+	isDark := IsSystemDarkMode()
+	
+	settings, _ := gtk.SettingsGetDefault()
+	settings.SetProperty("gtk-application-prefer-dark-theme", isDark)
+	
+	w.updateStyle()
+}
+
+// watchThemeChanges registers a dbus signal to update the theme when the setting changes
+func (w *MainWindow) watchThemeChanges() {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return
+	}
+	
+	rule := "type='signal',interface='org.freedesktop.portal.Settings',member='SettingChanged'"
+	conn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, rule)
+
+	c := make(chan *dbus.Signal, 10)
+	conn.Signal(c)
+
+	go func() {
+		for sig := range c {
+			if len(sig.Body) >= 2 && 
+			   sig.Body[0] == "org.freedesktop.appearance" && 
+			   sig.Body[1] == "color-scheme" {
+				   glib.IdleAdd(func() {
+					   w.syncWithPortal()
+				   })
+			   }
+		}
+	}()
 }


### PR DESCRIPTION
Should solve https://github.com/yktoo/ymuse/issues/98.

Should now use the light/dark variants of a gtk theme based on the dbus portal settings.